### PR TITLE
7 onboarding checklist

### DIFF
--- a/checklists/NEW_CONTRACTOR.md
+++ b/checklists/NEW_CONTRACTOR.md
@@ -1,0 +1,16 @@
+# New Contractor Onboarding
+
+- Ping `@Tommy Davis` in Slack to create an Adapt Email address for the new contractor. We typically use `firstname.lastname@adaptagency.com`, so please provide him with this information. All account access below should use Adapt email adress. Github is the exception to this rule, if the contractor has an existing account it's ok to use it.
+- Add new contractor to Github teams
+  - https://github.com/orgs/adaptdk/teams/adapt-usa
+  - Project specific team(s)
+- Invite to Slack (limit them to project specific channels)
+- Welcome them in the project specific Slack channel with a message
+- Invite to Zenhub (purchase additional seat if needed)
+- Invite to Harvest and assign to appropriate project(s)
+- Invite to Basecamp project
+- Add to any existing standup / meeting invites
+- Schedule on boarding call with project lead
+  - Review project goals
+  - Review Adapt [workflow norms](../project-workflow/README.md)
+- Assign them a project specific on boarding ticket. These are generic tickets that can be used for every developer on the project in order to get them familar with the project's environment.

--- a/checklists/NEW_CONTRACTOR.md
+++ b/checklists/NEW_CONTRACTOR.md
@@ -1,16 +1,15 @@
 # New Contractor Onboarding
 
-- Ping `@Tommy Davis` in Slack to create an Adapt Email address for the new contractor. We typically use `firstname.lastname@adaptagency.com`, so please provide him with this information. All account access below should use Adapt email adress. Github is the exception to this rule, if the contractor has an existing account it's ok to use it.
-- Add new contractor to Github teams
+- [ ] Ping `@Tommy Davis` in Slack to create an Adapt Email address for the new contractor. We typically use `firstname.lastname@adaptagency.com`, so please provide him with this information. All account access below should use Adapt email adress. Github is the exception to this rule, if the contractor has an existing account it's ok to use it.
+- [ ] Add new contractor to Github teams
   - https://github.com/orgs/adaptdk/teams/adapt-usa
   - Project specific team(s)
-- Invite to Slack (limit them to project specific channels)
-- Welcome them in the project specific Slack channel with a message
-- Invite to Zenhub (purchase additional seat if needed)
-- Invite to Harvest and assign to appropriate project(s)
-- Invite to Basecamp project
-- Add to any existing standup / meeting invites
-- Schedule on boarding call with project lead
+- [ ] Invite to Slack (limit them to project specific channels)
+- [ ] Invite to Zenhub (purchase additional seat if needed)
+- [ ] Invite to Harvest and assign to appropriate project(s)
+- [ ] Invite to Basecamp project
+- [ ] Add to any existing standup / meeting invites
+- [ ] Schedule on boarding call with project lead
   - Review project goals
   - Review Adapt [workflow norms](../project-workflow/README.md)
-- Assign them a project specific on boarding ticket. These are generic tickets that can be used for every developer on the project in order to get them familar with the project's environment.
+- [ ] Assign them a project specific on boarding ticket. These are generic tickets that can be used for every developer on the project in order to get them familar with the project's environment.

--- a/checklists/NEW_PROJECT.md
+++ b/checklists/NEW_PROJECT.md
@@ -2,11 +2,11 @@
 
 Not every project is identical, so it's possible that not all of these items will be relevant to your project. Use your best judgement, and don't heistate to ask the team if you have questions. Some of these tasks can be taken on by the PM if desired.
 
-- [] Create Github team for project (see [documentation regarding team structure](../github-team-structure/README.md))
-- [] Crate new Github repo
-- [] Crate new Zenhub project
-- [] Crate new Basecamp project (invite internal + external team members)
-- [] Establish internal meeting cadence (aka standups) dependent on schedule + project size.
-- [] Establish external meeting cadence with client
-- [] Create Harvest project + assign team members
-- [] Schedule regular budget reviews
+- [ ] Create Github team for project (see [documentation regarding team structure](../github-team-structure/README.md))
+- [ ] Crate new Github repo
+- [ ] Crate new Zenhub project
+- [ ] Crate new Basecamp project (invite internal + external team members)
+- [ ] Establish internal meeting cadence (aka standups) dependent on schedule + project size.
+- [ ] Establish external meeting cadence with client
+- [ ] Create Harvest project + assign team members
+- [ ] Schedule regular budget reviews

--- a/checklists/NEW_PROJECT.md
+++ b/checklists/NEW_PROJECT.md
@@ -1,0 +1,12 @@
+# New Project Checklist
+
+Not every project is identical, so it's possible that not all of these items will be relevant to your project. Use your best judgement, and don't heistate to ask the team if you have questions. Some of these tasks can be taken on by the PM if desired.
+
+- [] Create Github team for project (see [documentation regarding team structure](../github-team-structure/README.md))
+- [] Crate new Github repo
+- [] Crate new Zenhub project
+- [] Crate new Basecamp project (invite internal + external team members)
+- [] Establish internal meeting cadence (aka standups) dependent on schedule + project size.
+- [] Establish external meeting cadence with client
+- [] Create Harvest project + assign team members
+- [] Schedule regular budget reviews

--- a/github-team-structure/README.md
+++ b/github-team-structure/README.md
@@ -1,0 +1,18 @@
+# Github Team Organizaion
+
+Repository access is managed via Github's Team feature.
+
+## Adapt USA
+
+We have an overarching team, called [Adapt USA](https://github.com/orgs/adaptdk/teams/adapt-usa/members). All team members that work with
+the US team should belong to this group (including contractors). It grants
+access to relatively insensitive material, shuch as this documentation wiki. This
+group should not be given access to client repositories.
+
+## Client Projects
+
+Access to client project repositories should be granted via a sub-group specific to that client. This team should be a child of `Adapt USA` team to keep organization clean. Only team members actively working on the project should be granted access to this team.
+
+## Restricting Repository Access
+
+In some projects, it may be good to protect the `main` branch by enabling [branch restrictions](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/enabling-branch-restrictions). If this strategy is used, create a second nested team that further restricts the client specfic team to a set of trusted administrators. This setup makes the most sense when working with collaborators that are not yet trusted team members.


### PR DESCRIPTION
Fixes issue #8 
Fixes issue #7 
Fixes issue #6 

## Summary of changes

1. Documents new project setup checklist
1. Documents Github team structure
1. Adds contractor onboarding checklist

## Reason for change

Both the new project + contractor onboarding checklists document processes that are repetitive but error prone. Instead of remembering all the steps to do each task, we now have an easy checklist to follow (and add to if needed).

Documenting Github team structure feels important because it's how we delegate access to certain repositories. If we don't use it correctly people get repo access that shouldn't.