### PR TITLE
Typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Adapt USA Workflow Documentation
 
 ## New Developers
 
-If you're new to the team, please start by going through the [New Developer Onboarding](/developer-onboarding) section. Otherwise, use the sidebar to navigate the contents of the wiki.
+If you're new to the team, please start by going through the [New Developer Onboarding](/developer-onboarding) section.
+Otherwise, please navigate the contents.
 
 
 ## Contributing

--- a/checklists/NEW_CONTRACTOR.md
+++ b/checklists/NEW_CONTRACTOR.md
@@ -1,6 +1,6 @@
 # New Contractor Onboarding
 
-- [ ] Ping `@Tommy Davis` in Slack to create an Adapt Email address for the new contractor. We typically use `firstname.lastname@adaptagency.com`, so please provide him with this information. All account access below should use Adapt email adress. Github is the exception to this rule, if the contractor has an existing account it's ok to use it.
+- [ ] Ping `@Tommy Davis` in Slack to create an Adapt Email address for the new contractor. We typically use `firstname.lastname@adaptagency.com`, so please provide him with this information. All account access below should use Adapt email address. Github is the exception to this rule, if the contractor has an existing account it's OK to use it.
 - [ ] Add new contractor to Github teams
   - https://github.com/orgs/adaptdk/teams/adapt-usa
   - Project specific team(s)
@@ -12,4 +12,4 @@
 - [ ] Schedule on boarding call with project lead
   - Review project goals
   - Review Adapt [workflow norms](../project-workflow/README.md)
-- [ ] Assign them a project specific on boarding ticket. These are generic tickets that can be used for every developer on the project in order to get them familar with the project's environment.
+- [ ] Assign them a project specific on boarding ticket. These are generic tickets that can be used for every developer on the project in order to get them familiar with the project's environment.

--- a/checklists/NEW_PROJECT.md
+++ b/checklists/NEW_PROJECT.md
@@ -1,11 +1,11 @@
 # New Project Checklist
 
-Not every project is identical, so it's possible that not all of these items will be relevant to your project. Use your best judgement, and don't heistate to ask the team if you have questions. Some of these tasks can be taken on by the PM if desired.
+Not every project is identical, so it's possible that not all of these items will be relevant to your project. Use your best judgement, and don't hesitate to ask the team if you have questions. Some of these tasks can be taken on by the PM if desired.
 
 - [ ] Create Github team for project (see [documentation regarding team structure](../github-team-structure/README.md))
-- [ ] Crate new Github repo
-- [ ] Crate new Zenhub project
-- [ ] Crate new Basecamp project (invite internal + external team members)
+- [ ] Create new Github repo
+- [ ] Create new Zenhub project
+- [ ] Create new Basecamp project (invite internal + external team members)
 - [ ] Establish internal meeting cadence (aka standups) dependent on schedule + project size.
 - [ ] Establish external meeting cadence with client
 - [ ] Create Harvest project + assign team members

--- a/code-reviews/README.md
+++ b/code-reviews/README.md
@@ -13,26 +13,26 @@
 ## Having your code reviewed
 
 - Remember that the person reviewing your work does not have as much context as
-  you do. Provide them with as much context as you feel will be nessicary for
+  you do. Provide them with as much context as you feel will be necessary for
   them to understand the changes you're proposing.
 - A great way to provide context to the reviewer is to use Github's review
   features. For instance, if there is a line of code that you think will be
   confusing, comment inline on code in your own PR so that the reviewer will
-  see it. You can find an [example of that in action](https://github.com/adaptdk/tufts-acsf/pull/335/files/fcfeee988c0082a24949cf18e66464fc518bc7e9#diff-8d31c81cc321d8731734e8da9e3af11a10306595cb94532b4d47c226582d9b32) on the Tufts ACSF proeject.
+  see it. You can find an [example of that in action](https://github.com/adaptdk/tufts-acsf/pull/335/files/fcfeee988c0082a24949cf18e66464fc518bc7e9#diff-8d31c81cc321d8731734e8da9e3af11a10306595cb94532b4d47c226582d9b32) on the Tufts ACSF project.
 - Always provide thorough testing steps so that the reviewer can test appropriately. Testing steps include:
   - Any steps needed to get your environment into the state that should be tested
-  - Any manual setup setps that need to happen prior to testing
+  - Any manual setup steps that need to happen prior to testing
   - Testing steps + expected outcomes
 
 ## Work in small batches
 
 Whenever possible, favor small, frequently submitted batches of work over large infrequently submitted batches. Small batches of work are easier for a reviewer to reason about.
 
-For instance, if you are assigned a ticket that will require changes to multiple parts of the system, consider submitting several PRs, one for each part of the system. This will allow the reviwer the opportunity to review each change in isolation, allowing them to provide better feedback.
+For instance, if you are assigned a ticket that will require changes to multiple parts of the system, consider submitting several PRs, one for each part of the system. This will allow the reviewer the opportunity to review each change in isolation, allowing them to provide better feedback.
 
 Submitting small PRs early in the process also allows for early review from peers. For instance, if you aren't sure the best way to implement something, push up a WIP PR and ask for feedback from the team.
 
-Keep in mind that `main` branch should always be in a deployable state. If you submit a PR that relies on work not yet complete, ensure that merging your initial PR will not bring `main` into a non-functional state. How to acheive this is a judgement call dependent on the situation, but usually their are logical boundaries which can be used to segment what goes into a PR. If needed you can always fall back to a single, larger PR utilizing the WIP PR state on Github to allow others the opportunity to review as you go.
+Keep in mind that `main` branch should always be in a deployable state. If you submit a PR that relies on work not yet complete, ensure that merging your initial PR will not bring `main` into a non-functional state. How to achieve this is a judgement call dependent on the situation, but usually their are logical boundaries which can be used to segment what goes into a PR. If needed you can always fall back to a single, larger PR utilizing the WIP PR state on Github to allow others the opportunity to review as you go.
 
 ## Reduce the number of handoffs
 
@@ -47,6 +47,6 @@ This task falls to the project lead / architect by default, but when the
 balance falls too far out of line, it takes up a large amount of time for that
 person. This leads to lower quality review + fatigue on the architect.
 
-Another benefit of sharing code review responsibilities is that domain knwoledge
+Another benefit of sharing code review responsibilities is that domain knowledge
 is spread out amongst team members. This helps prevent individual team members
 from becoming single points of failure on a project.

--- a/education/README.md
+++ b/education/README.md
@@ -1,13 +1,13 @@
 # Education Resources
 
-Part of being a good developer is the desire to learn new things. We want to support our staff members in their learning journey as much as possilbe.
+Part of being a good developer is the desire to learn new things. We want to support our staff members in their learning journey as much as possible.
 
 ## [Development Library](https://drive.google.com/drive/folders/1SNgViiZ95-csuquivYom340VC38KD6P0?usp=sharing)
 
-We buy books for use by the development team and store them in Google Drive (see link above). These books are availalbe to anyone at Adapt, feel free to download + consume at your leasure. If you have a book that you want to add to the libray, talk to your supervious about purchasing it + adding to the library. Once you do let the team know it's available to them!
+We buy books for use by the development team and store them in Google Drive (see link above). These books are available to anyone at Adapt, feel free to download + consume at your leisure. If you have a book that you want to add to the library, talk to your supervisor about purchasing it + adding to the library. Once you do let the team know it's available to them!
 
-**Note**: We may techincally be breaking DRM by sharing books this way. Please do not share these outside of Adapt
+**Note**: We may technically be breaking DRM by sharing books this way. Please do not share these outside of Adapt
 
 ## New Purchases
 
-Talk to your supervisor if you're interested in purchasing new learning materials. This could be anything from a new book, to an online course, or even attending a conference you're intersted in. As long as it's related to the business we will do our best to purchase it for you, resources permitting.
+Talk to your supervisor if you're interested in purchasing new learning materials. This could be anything from a new book, to an online course, or even attending a conference you're interested in. As long as it's related to the business we will do our best to purchase it for you, resources permitting.

--- a/github-team-structure/README.md
+++ b/github-team-structure/README.md
@@ -1,4 +1,4 @@
-# Github Team Organizaion
+# Github Team Organization
 
 Repository access is managed via Github's Team feature.
 
@@ -6,7 +6,7 @@ Repository access is managed via Github's Team feature.
 
 We have an overarching team, called [Adapt USA](https://github.com/orgs/adaptdk/teams/adapt-usa/members). All team members that work with
 the US team should belong to this group (including contractors). It grants
-access to relatively insensitive material, shuch as this documentation wiki. This
+access to relatively insensitive material, such as this documentation wiki. This
 group should not be given access to client repositories.
 
 ## Client Projects
@@ -15,4 +15,4 @@ Access to client project repositories should be granted via a sub-group specific
 
 ## Restricting Repository Access
 
-In some projects, it may be good to protect the `main` branch by enabling [branch restrictions](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/enabling-branch-restrictions). If this strategy is used, create a second nested team that further restricts the client specfic team to a set of trusted administrators. This setup makes the most sense when working with collaborators that are not yet trusted team members.
+In some projects, it may be good to protect the `main` branch by enabling [branch restrictions](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/enabling-branch-restrictions). If this strategy is used, create a second nested team that further restricts the client specific team to a set of trusted administrators. This setup makes the most sense when working with collaborators that are not yet trusted team members.

--- a/issue-templates/Deployment-Ticket-Template.md
+++ b/issue-templates/Deployment-Ticket-Template.md
@@ -1,7 +1,7 @@
 ```
-- [ ] Merge the `release` branch into `develop` + `master` branches
-- [ ] Tag the `master` branch with the sprint number
-- [ ] Push the `master` branch to production
+- [ ] Merge the `release` branch into `develop` + `main` branches
+- [ ] Tag the `main` branch with the sprint number
+- [ ] Push the `main` branch to production
 - [ ] Insert manual deployment steps here
 - [ ] Add date + time of deployment to deployment ticket along with any important notes (issues encountered etc)
 - [ ] Close deployment ticket

--- a/project-workflow/README.md
+++ b/project-workflow/README.md
@@ -14,7 +14,7 @@ This is a living document that will change as we learn and grow as an organizati
 
 ## Gathering Requirements
 
-This is a the first and arguably most critical part of the project life cycle. It is vital that we gather requirements precisely so that client expectations are lockstep with our own.
+This is the first and arguably most critical part of the project life cycle. It is vital that we gather requirements precisely so that client expectations are lockstep with our own.
 
 At the end of this phase, we should know the following:
 
@@ -41,7 +41,7 @@ When we begin a new project, the following infrastructure needs to be establishe
 * Create a new Workspace in Zenhub
   * Ensure that the following Pipelines are in place:
     * New Issues: Where issues go that have yet to be prioritized
-    * Backlog: Issues move into the Backlog once they are assigned to a developer and are ready for implemntation
+    * Backlog: Issues move into the Backlog once they are assigned to a developer and are ready for implementation
     * In Progress: Issues that are currently being worked on
     * Review / QA: Catchall for code review and functional QA
     * Done: Merged into the main development branch, but not yet deployed to production

--- a/standups/README.md
+++ b/standups/README.md
@@ -15,7 +15,7 @@ Pretty simple 😉
 * Standup meetings should be scheduled for 15 minutes
 * Put the 3 questions that everyone is expected to answer in the meeting invite
 * Share your screen, with following windows open:
-  * Speaker order for that meeting. Consider randomizing the order with [a tool like this](https://www.browserling.com/tools/random-lines?input=Jack%0AJill%0ADiane) (notice the names in the URL, which allow you to re-use the link without typing in everyones name again)
+  * Speaker order for that meeting. Consider randomizing the order with [a tool like this](https://www.browserling.com/tools/random-lines?input=Jack%0AJill%0ADiane) (notice the names in the URL, which allow you to re-use the link without typing in everyone's name again)
   * Kanban board for the current sprint, filtered by the person that's currently speaking
 * Primary goals of a standup
   * **Provide a shared understanding of project goals:** Even if everyone is on the same page at the beginning of a project, understanding tends to shift / deteriorate over time. Standup meetings provide small course corrections which ensure we maintain alignment.


### PR DESCRIPTION
## Summary of changes

1. Lots of typo fixes
1. Remove wiki reference.

## Reason for change

Typos, well, less typos is better.
Wiki is duplicating content, I remove duplicated content from the wiki, so remove the reference to it here.