### PR TITLE
#17 Document ticket assignment methods

### DIFF
--- a/project-workflow/README.md
+++ b/project-workflow/README.md
@@ -77,6 +77,23 @@ Tickets in the active sprint are organized into pipelines. Those are:
   * Done: Merged into develop branch, but not yet deployed to production
   * Closed: Deployed to production
 
+### Ticket Assignment
+
+Ticket assignment can handled in one of two ways:
+
+- Top down assignment
+- Open backlog (preferred)
+
+#### Top down assignment
+
+This is the more traditional approach where the project lead assigns tickets to developers explicitly. This approach gives the project lead a lot of control over the order in which tickets get completed and by whom. It also puts the project lead in a bottleneck position. If a developer is out of tickets, but the project lead is not online, the developer is blocked. It also implies a low trust atmosphere on the development team.
+
+#### Open Backlog
+
+In this model, the project lead populates the backlog according to priority. Developers are then able to self-select tickets out of the backlog based on priority & required skill set. When selecting a ticket, a developer chooses the highest priority ticket that they feel capable of solving.
+
+In order for this to work, all tickets need to be well fleshed out and prioritized before the sprint starts, effectively holding the project lead accountable. This approach implies a high trust atmosphere on the development team.
+
 ## Development workflow
 
 Our development workflow centers around the [Gitflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow). You should be familiar with the general concepts before reading further.

--- a/project-workflow/README.md
+++ b/project-workflow/README.md
@@ -94,6 +94,8 @@ In this model, the project lead populates the backlog according to priority. Dev
 
 In order for this to work, all tickets need to be well fleshed out and prioritized before the sprint starts, effectively holding the project lead accountable. This approach implies a high trust atmosphere on the development team.
 
+In this context it is highly useful to use tags to help filtering out tickets on project boards.
+
 ## Development workflow
 
 Our development workflow centers around the [Gitflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow). You should be familiar with the general concepts before reading further.

--- a/project-workflow/README.md
+++ b/project-workflow/README.md
@@ -79,7 +79,7 @@ Tickets in the active sprint are organized into pipelines. Those are:
 
 ### Ticket Assignment
 
-Ticket assignment can handled in one of two ways:
+Ticket assignment can be handled in one of two ways:
 
 - Top down assignment
 - Open backlog (preferred)


### PR DESCRIPTION
Fixes issue [Issue 17](https://github.com/adaptdk/usa-documentation/issues/17)
  
## Summary of changes

1. Documents 2 options for ticket assignment 
2. States preference for "open assignment" method

## Reason for change

We experimented with the "open assignment" method on the ACSF project and it was quite successful. Developers liked it better because they had more agency over what they worked on. It was also nice as the project lead because it forced me to get everything organized before the sprint & made it so that I wasn't the bottleneck for getting tickets assigned.
