### PR TITLE
Update onboarding and project workflow documentation.

### DIFF
--- a/frontend-methodologies/README.md
+++ b/frontend-methodologies/README.md
@@ -1,3 +1,6 @@
+*@outdated: This content may be a useful reference but it's not
+  how we approach all frontend projects at this point.*
+
 What follows is our preferred methodology for front-end development. Keeping our front-end tooling consistent across projects should help reduce context switching. Refer to the theme in our [Drupal 8 starter](https://github.com/adaptdk/drupal8-starter) for an example implementation.
 
 These rules aren't set in stone. In the [words of Orwell](https://www.writingclasses.com/toolbox/tips-masters/george-orwell-6-questions-6-rules):

--- a/project-workflow/README.md
+++ b/project-workflow/README.md
@@ -42,9 +42,7 @@ We use milestones to organize our work. This is how milestones should be set up:
 * Our preferred milestone length is 2 weeks.
   * For maintenance projects, it is acceptable not to create milestones. Maintenance projects typically do not have many active issues, so we do not need to open and close milestones needlessly.
 * At the start of each milestone, the following tasks should be completed by the project lead / PM:
-  * Create a deployment ticket to be used to track time spent on deployments, as well as any manual deployment steps specific to this deployment. Use [this template](/issue-templates/Deployment-Ticket-Template.md) for deployment tickets.
   * Assign an estimate to each ticket (in hours). This is used for planning purposes, as well as to set expectations with the assigned developer. Technically, Zenhub tracks estimates as story points, but we find these to be too vague for the context in which we operate.
-  * Assign each ticket in the sprint to a developer based on that developers capacity & the estimates developed in the previous step.
 
 
 ## Ticketing workflow
@@ -101,8 +99,10 @@ Our development workflow centers around the [Gitflow](https://www.atlassian.com/
 
 ## Time tracking
 
-* All time should be logged to a specific ticket in Harvest.
-* It is recommended to use the [Harvest plugin for chrome](https://chrome.google.com/webstore/detail/harvest-time-tracker/fbpiglieekigmkeebmeohkelfpjjlaia?hl=en) to make time tracking easier (Firefox equivalent looks to exist)
+* All time should be logged to in Forecast.app.  Tickets are not opened in forecast,
+  instead time is logged based on a generic task such as "Development".
+* When logging time, please choose the correct task and add a brief note about what
+  you did, with a link to the ticket or PR if possible.
 
 ## Client communication
 
@@ -114,6 +114,6 @@ Our development workflow centers around the [Gitflow](https://www.atlassian.com/
 ## Tooling
 
 - Git repo: Github
-- Ticketing: Github
-- Time tracking: Harvest
+- Ticketing: Github / Zenhub
+- Time tracking: Forecast.app
 - Client communication: Basecamp

--- a/standups/README.md
+++ b/standups/README.md
@@ -18,8 +18,8 @@ Pretty simple.
 * Standup meetings should be scheduled for 15 minutes
 * Put the 3 questions that everyone is expected to answer in the meeting invite
 * Share your screen, with following windows open:
-  * Speaker order for that meeting. Consider randomizing the order with [a tool like this](https://www.browserling.com/tools/random-lines?input=Jack%0AJill%0ADiane) (notice the names in the URL, which allow you to re-use the link without typing in everyone's name again)
   * Kanban board for the current sprint, filtered by the person that's currently speaking
+  * Consider randomizing the order of speakers with [a tool like this](https://www.browserling.com/tools/random-lines?input=Jack%0AJill%0ADiane) (notice the names in the URL, which allow you to re-use the link without typing in everyone's name again)
 * Primary goals of a standup
   * **Provide a shared understanding of project goals:** Even if everyone is on the same page at the beginning of a project, understanding tends to shift / deteriorate over time. Standup meetings provide small course corrections which ensure we maintain alignment.
   * **Allow space for sharing problems & solutions:** If a team member is having trouble with an issue, this is a great time for other team members to offer solutions. Typically, these solutions should be discussed outside the standup, but this is a good space to identify those follow up discussions.


### PR DESCRIPTION
## Summary of changes

* Update the project workflow docs to reflect current practices
* Tag the `frontend-methodologies` file as outdated

## Reason for changes

We're bringing on another contractor.  Tess has put together a document that points them to our developer onboarding docs.  This seems like a good thing except that we're fairly out of date at this point.  Frontend methodologies doesn't match how we use Chakra and Nextjs, and project workflow doesn't really fit how we work in github.  We tend to not use milestones at this point.