### PR TITLE
Add info on spreading out code reviews.

### DIFF
--- a/code-reviews/README.md
+++ b/code-reviews/README.md
@@ -49,6 +49,11 @@ When to do this is a judgment call. In general, choose the route that will help 
   code reviews, feel free to delegate reviews to other team members.  It is not
   only your responsibility to review code.  The team needs to see what others are
   doing and understand how or why it was done.
+* When requesting a review, do not tag the entire team.  Assign one or two
+  reviewers at most.  This will help the reviewers know who is responsible
+  for the next step.  Requesting too many reviewers may cause team members
+  to assume someone else will handle the task and the PR will be stranded in
+  limbo 🙁
 
 As much as possible we should share code reviews between the core team members.
 Often, we default to requesting code reviews from the project lead / architect,

--- a/code-reviews/README.md
+++ b/code-reviews/README.md
@@ -40,12 +40,20 @@ Each hand-off requires context switching and communication, all of which take ti
 
 When to do this is a judgment call. In general, choose the route that will help the team progress the fastest. In other words, if you can eliminate the need for a hand-off by making a change yourself, this is usually the preferred option. On the other hand, if the needed change is large, intricate, or would provide useful context and learning opportunities for the dev, it's likely better to request changes from the original dev and incur the cost of the hand-off. In other words, it's a trade-off.
 
-## Democratize code review
+## Code reviews are for everyone
+
+* If you are a team member on a project, request code reviews from a variety
+  of team members.  This shares both the knowledge and the burden of the code
+  review.
+* If you are the team lead of a project and you are being asked to do a lot of
+  code reviews, feel free to delegate reviews to other team members.  It is not
+  only your responsibility to review code.  The team needs to see what others are
+  doing and understand how or why it was done.
 
 As much as possible we should share code reviews between the core team members.
-This task falls to the project lead / architect by default, but when the
-balance falls too far out of line, it takes up a large amount of time for that
-person. This leads to lower quality review + fatigue on the architect.
+Often, we default to requesting code reviews from the the project lead / architect,
+but when the balance falls too far out of line, it takes up a large amount of time
+for that person. This leads to lower quality review + fatigue on the architect.
 
 Another benefit of sharing code review responsibilities is that domain knowledge
 is spread out amongst team members. This helps prevent individual team members

--- a/code-reviews/README.md
+++ b/code-reviews/README.md
@@ -51,7 +51,7 @@ When to do this is a judgment call. In general, choose the route that will help 
   doing and understand how or why it was done.
 
 As much as possible we should share code reviews between the core team members.
-Often, we default to requesting code reviews from the the project lead / architect,
+Often, we default to requesting code reviews from the project lead / architect,
 but when the balance falls too far out of line, it takes up a large amount of time
 for that person. This leads to lower quality review + fatigue on the architect.
 


### PR DESCRIPTION
## Summary of changes

1. Adds information to the code review documentation about spreading out and delegating reviews.

## Reason for change

This came up as a discussion in our Team Leads.  We have been working on sharing code reviews in the precision digital project and it has felt like a positive for all team members.
