### PR TITLE
Suggest auto-linking of pull requests

### DIFF
--- a/issue-templates/pull_request_template.md
+++ b/issue-templates/pull_request_template.md
@@ -5,7 +5,7 @@ Creating the PR.
 -->
 
 <!-- Fill a related issue number, e.g. #123. -->
-Fixes issue #.
+Fixes #.
   
 ## Summary of changes
 


### PR DESCRIPTION
## Summary of changes

1. Changes syntax of issue reference to get auto-linking from pull request to issue.

## Reason for change

In order to get automatic linking on the _Linked issues_ field on GitHub pull requests, the syntax `fixes #123` should be followed.
See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue